### PR TITLE
fix(overwriteModule): bug in DynamicModule name search

### DIFF
--- a/packages/nestjs-test-utilities/src/lib/builders/module/module.builder.ts
+++ b/packages/nestjs-test-utilities/src/lib/builders/module/module.builder.ts
@@ -3,7 +3,8 @@ import {
   Type,
   Provider,
   DynamicModule,
-  NotImplementedException,
+  ForwardReference,
+  NotImplementedException
 } from "@nestjs/common";
 import { Test, TestingModuleBuilder } from "@nestjs/testing";
 import * as _ from "lodash";
@@ -11,6 +12,8 @@ import * as _ from "lodash";
 export type NestJSModule =
   | Type<unknown>
   | DynamicModule
+  | Promise<DynamicModule>
+  | ForwardReference<unknown>;
 
 export interface ITestModuleBuilder {
   build(): TestingModuleBuilder | Promise<TestingModuleBuilder>;
@@ -55,15 +58,15 @@ export class TestModuleBuilder implements ITestModuleBuilder {
       const module = this.imports[index] as NestJSModule;
       const imports = Reflect.getMetadata("imports", module);
 
-      const targetIndex = imports.findIndex((nestModule: NestJSModule ) => {
-        if (typeof nestModule === "function") {
-          return nestModule["name"] === target.name
-        } else if (typeof nestModule === "object") {
-          const innerModule: NestJSModule = nestModule.module
+      const targetIndex = imports.findIndex((m: any) => {
+        if (typeof m === "function") {
+          return m["name"] === target.name
+        } else if (typeof m === "object") {
+          const innerModule = m.module
           return innerModule ? innerModule["name"] === target.name : false
         } else {
           throw new NotImplementedException(
-            `${typeof nestModule} is not supported by overrideModule`
+            `${typeof m} is not supported by overrideModule`
           );
         }
       });

--- a/packages/nestjs-test-utilities/src/lib/builders/module/module.builder.ts
+++ b/packages/nestjs-test-utilities/src/lib/builders/module/module.builder.ts
@@ -57,7 +57,17 @@ export class TestModuleBuilder implements ITestModuleBuilder {
       const module = this.imports[index] as NestJSModule;
       const imports = Reflect.getMetadata("imports", module);
 
-      const targetIndex = imports.findIndex((m: any) => m["name"] === target.name);
+      const targetIndex = imports.findIndex((m) => {
+        if (typeof m === "function") {
+          return m["name"] === target.name
+        } else if (typeof m === "object") {
+          const innerModule = m.module
+          return innerModule ? innerModule["name"] === target.name : false
+        } else {
+          // NOT SUPPORTED
+          return false
+        }
+      });
       if (targetIndex > -1) {
         Reflect.defineMetadata("imports", [...imports.slice(0, targetIndex), nestModule, ...imports.slice(targetIndex + 1)], module);
       }


### PR DESCRIPTION
#7 Turns out DynamicModules need to dig into a nested object first to get the Module Class